### PR TITLE
Remove background image in popups. Fix background colors for dark mode.

### DIFF
--- a/source/addLinksToPage.js
+++ b/source/addLinksToPage.js
@@ -1,6 +1,5 @@
 export default function addLinksToPage(options, links) {
     const url = location.href;
-    const logoUrl = chrome.runtime.getURL('images/logo-256.png');
     const optionsUrl = chrome.runtime.getURL('options.html');
 
     function copyLinkToClipboard({ url, text }) {
@@ -95,7 +94,6 @@ export default function addLinksToPage(options, links) {
 
                 const linkPopupBody = document.createElement('div');
                 linkPopupBody.className = 'copy-github-link-body';
-                linkPopupBody.setAttribute('style', `background-image: url('${logoUrl}');`);
 
                     const linkPopupBodyContent = document.createElement('div');
                     linkPopupBodyContent.className = 'copy-github-link-body-content';

--- a/source/content-styles.css
+++ b/source/content-styles.css
@@ -7,6 +7,10 @@ h5 {
     z-index: unset;
 }
 
+.copy-github-link-container a.BtnGroup-item, .copy-github-link-container summary.BtnGroup-item {
+    background: transparent;
+}
+
 .copy-github-link-container div.dropdown-menu {
     top:6px;
     width: max-content;
@@ -18,15 +22,13 @@ h5 {
 }
 
 .copy-github-link-body {
-  background-position: center;
-  background-repeat: no-repeat;
   min-height: 256px;
   margin: 0;
   padding: 0;
 }
 
 .copy-github-link-body .copy-github-link-body-content {
-  background-color: rgba(255, 255, 255, 0.9);
+  background-color: var(--bgColor-muted, var(--color-canvas-subtle));
   padding: 8px 12px;
   min-height: 256px;
 }

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Copy GitHub Link",
     "description": "Copy formatted GitHub links for issues, pull requests, repositories, users, and more.",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "icons": {
         "32": "images/icon-32-enabled.png",
         "64": "images/icon-64-enabled.png",

--- a/source/popup.css
+++ b/source/popup.css
@@ -1,7 +1,4 @@
 html {
-  background-image: url('images/logo-256.png');
-  background-position: center;
-  background-repeat: no-repeat;
   margin: 0;
   padding: 0;
   width: max-content;


### PR DESCRIPTION
Fixes #21
Fixes #22 

I chose not to bother with a config option for turning off the popup background image; I just removed it instead.