### PR TITLE
Support issues in repos with Issue Types

### DIFF
--- a/source/addLinksToPage.js
+++ b/source/addLinksToPage.js
@@ -227,7 +227,15 @@ export default function addLinksToPage(options, links) {
         renderLinkButton(appHeader, 'div', options.disableAppHeaderButton, 'appheader', false, '', 'pl-2 pr-2');
     }
 
-    const [pullRequestOrIssueHeader] = [...document.getElementsByClassName('gh-header-actions')];
+    // With the new Issue Types (https://github.blog/changelog/2024-10-01-evolving-github-issues-public-preview/),
+    // the action block no longer has a unique class name, so search for it by `data-component` tag,
+    // but fall back to the older approach for repos that don't have types enabled.
+    const newHeaderOuterDiv = document.querySelector('[data-component="PH_Actions"]');
+    const newActionHeader = newHeaderOuterDiv ? newHeaderOuterDiv.firstElementChild : null;
+
+    const [oldStyleActionHeader] = [...document.getElementsByClassName('gh-header-actions')];
+
+    const pullRequestOrIssueHeader = newActionHeader || oldStyleActionHeader;
 
     if (pullRequestOrIssueHeader) {
         renderLinkButton(pullRequestOrIssueHeader, 'div', options.disablePullRequestIssueButton, 'pullorissue', true, 'btn-sm');

--- a/source/addLinksToPage.js
+++ b/source/addLinksToPage.js
@@ -67,7 +67,7 @@ export default function addLinksToPage(options, links) {
             buttonGroupDetails.setAttribute('data-view-component', true);
 
                 const buttonGroupSummary = document.createElement('summary');
-                buttonGroupSummary.className = `${buttonClass} btn BtnGroup-item px-2 float-none ml-0`;
+                buttonGroupSummary.className = `${buttonClass} btn btn-block BtnGroup-item px-2 float-none ml-0`;
                 buttonGroupSummary.setAttribute('data-view-component', true);
                 buttonGroupSummary.setAttribute('role', 'button');
                 buttonGroupSummary.setAttribute('aria-haspopup', true);
@@ -235,15 +235,18 @@ export default function addLinksToPage(options, links) {
 
     const [oldStyleActionHeader] = [...document.getElementsByClassName('gh-header-actions')];
 
+    // The new Issue Types UI no longer uses `btn-sm` style on the buttons
+    const buttonClass = !!newActionHeader ? '' : 'btn-sm';
+
     const pullRequestOrIssueHeader = newActionHeader || oldStyleActionHeader;
 
     if (pullRequestOrIssueHeader) {
-        renderLinkButton(pullRequestOrIssueHeader, 'div', options.disablePullRequestIssueButton, 'pullorissue', true, 'btn-sm');
+        renderLinkButton(pullRequestOrIssueHeader, 'div', options.disablePullRequestIssueButton, 'pullorissue', true, buttonClass);
     }
 
     const [pageHeadActions] = [...document.getElementsByClassName('pagehead-actions')];
 
     if (pageHeadActions) {
-        renderLinkButton(pageHeadActions, 'li', options.disableRepoHeaderButton, 'repoheader', true, 'btn-sm');
+        renderLinkButton(pageHeadActions, 'li', options.disableRepoHeaderButton, 'repoheader', true, buttonClass);
     }
 }

--- a/source/content-styles.css
+++ b/source/content-styles.css
@@ -28,9 +28,10 @@ h5 {
 }
 
 .copy-github-link-body .copy-github-link-body-content {
-  background-color: var(--bgColor-muted, var(--color-canvas-subtle));
   padding: 8px 12px;
   min-height: 256px;
+  font-size: var(--body-font-size, 14px);
+  font-weight: initial;
 }
 
 .copy-github-link-group {

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Copy GitHub Link",
     "description": "Copy formatted GitHub links for issues, pull requests, repositories, users, and more.",
-    "version": "1.3.8",
+    "version": "1.3.9",
     "icons": {
         "32": "images/icon-32-enabled.png",
         "64": "images/icon-64-enabled.png",


### PR DESCRIPTION
Looks like GitHub no longer always generates a

```html
<div class="gh-header-actions ...">
```

in favor of a

```html
<div class="Box-sc-g0xbh4-0 kcuWpx" data-component="PH_Actions">
  <div class="Box-sc-g0xbh4-0 cQpCwc">...
```

(I think because of new use of React).
